### PR TITLE
Create Time Tracker plugin panel

### DIFF
--- a/plugin/index.html
+++ b/plugin/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Time Tracker</title>
+    <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+    <div class="container">
+        <h1>Time Tracker</h1>
+        <button id="startBtn">Start Tracking</button>
+    </div>
+    <script src="main.js"></script>
+</body>
+</html>

--- a/plugin/main.js
+++ b/plugin/main.js
@@ -1,0 +1,3 @@
+document.getElementById('startBtn').addEventListener('click', () => {
+    console.log('Tracking started');
+});

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,0 +1,20 @@
+{
+  "manifestVersion": 4,
+  "id": "com.example.timetracker",
+  "name": "Time Tracker",
+  "version": "1.0.0",
+  "main": "index.html",
+  "host": {
+    "app": "AEFT",
+    "minVersion": "22.0"
+  },
+  "ui": {
+    "type": "panel",
+    "menu": [
+      {
+        "label": "Time Tracker",
+        "command": "open"
+      }
+    ]
+  }
+}

--- a/plugin/styles.css
+++ b/plugin/styles.css
@@ -1,0 +1,11 @@
+body {
+    font-family: sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100vh;
+    margin: 0;
+}
+.container {
+    text-align: center;
+}


### PR DESCRIPTION
## Summary
- add UXP manifest for Time Tracker panel
- create basic HTML layout with a Start Tracking button
- log start event in main.js
- style plugin using sans-serif font and centered layout

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68682b2fd014832c85ca7be0ca7f36c5