### PR TITLE
Add per-project timer with idle pause

### DIFF
--- a/plugin/index.html
+++ b/plugin/index.html
@@ -8,16 +8,11 @@
 <body>
     <div class="container">
         <h1>Time Tracker</h1>
-        <div class="project-select">
-            <select id="projectSelect">
-                <option>Project A</option>
-            </select>
-            <button id="projectPlayBtn" class="icon-btn" aria-label="Play Project">
-                <!-- Play Icon -->
-                <svg viewBox="0 0 16 16" width="16" height="16">
-                    <polygon points="0,0 16,8 0,16" fill="currentColor" />
-                </svg>
-            </button>
+        <div id="projectName" class="project-name">Project</div>
+
+        <div class="idle-config">
+            <label for="idleInput">Idle timeout (min):</label>
+            <input id="idleInput" type="number" min="1" value="2" />
         </div>
 
         <div id="timer">00:00:00</div>
@@ -41,17 +36,9 @@
                 </svg>
             </button>
         </div>
-
-        <div class="icon-grid">
-            <button class="icon-btn" aria-label="Icon 1"></button>
-            <button class="icon-btn" aria-label="Icon 2"></button>
-            <button class="icon-btn" aria-label="Icon 3"></button>
-            <button class="icon-btn" aria-label="Icon 4"></button>
-            <button class="icon-btn" aria-label="Icon 5"></button>
-            <button class="icon-btn" aria-label="Icon 6"></button>
-        </div>
     </div>
 
+    <script src="storage.js"></script>
     <script src="main.js"></script>
 </body>
 </html>

--- a/plugin/main.js
+++ b/plugin/main.js
@@ -1,10 +1,27 @@
 let timer = null;
 let elapsedSeconds = 0;
+let idleTimeout = 2 * 60 * 1000; // 2 minutes default
+let idleTimer = null;
+let pausedByIdle = false;
+let currentProject = '';
+
 const timerEl = document.getElementById('timer');
 const playBtn = document.getElementById('playBtn');
 const pauseBtn = document.getElementById('pauseBtn');
 const refreshBtn = document.getElementById('refreshBtn');
-const projectPlayBtn = document.getElementById('projectPlayBtn');
+const idleInput = document.getElementById('idleInput');
+const projectNameEl = document.getElementById('projectName');
+
+function getProjectName() {
+    try {
+        if (app.project && app.project.file) {
+            return app.project.file.name;
+        }
+    } catch (e) {
+        // not running in AE or project unsaved
+    }
+    return 'Untitled';
+}
 
 function formatTime(seconds) {
     const hrs = String(Math.floor(seconds / 3600)).padStart(2, '0');
@@ -23,12 +40,20 @@ function startTimer() {
         elapsedSeconds++;
         updateDisplay();
     }, 1000);
+    pausedByIdle = false;
 }
 
-function pauseTimer() {
+function pauseTimer(byIdle = false) {
     if (!timer) return;
     clearInterval(timer);
     timer = null;
+    pausedByIdle = byIdle;
+}
+
+function resumeTimer() {
+    if (!timer) {
+        startTimer();
+    }
 }
 
 function resetTimer() {
@@ -37,9 +62,65 @@ function resetTimer() {
     updateDisplay();
 }
 
-playBtn.addEventListener('click', startTimer);
-pauseBtn.addEventListener('click', pauseTimer);
-refreshBtn.addEventListener('click', resetTimer);
-projectPlayBtn.addEventListener('click', startTimer);
+function saveCurrentTime() {
+    if (currentProject) {
+        saveTime(currentProject, elapsedSeconds);
+    }
+}
 
-updateDisplay();
+function loadCurrentProject() {
+    elapsedSeconds = loadTime(currentProject);
+    updateDisplay();
+}
+
+function checkProjectChange() {
+    const name = getProjectName();
+    if (name !== currentProject) {
+        if (currentProject) {
+            saveCurrentTime();
+        }
+        currentProject = name;
+        projectNameEl.textContent = currentProject;
+        loadCurrentProject();
+    }
+}
+
+function handleIdle() {
+    pauseTimer(true);
+}
+
+function resetIdle() {
+    clearTimeout(idleTimer);
+    idleTimer = setTimeout(handleIdle, idleTimeout);
+    if (pausedByIdle) {
+        resumeTimer();
+    }
+}
+
+playBtn.addEventListener('click', startTimer);
+pauseBtn.addEventListener('click', () => pauseTimer(false));
+refreshBtn.addEventListener('click', resetTimer);
+
+['mousemove', 'keydown', 'focus'].forEach(evt => {
+    window.addEventListener(evt, resetIdle);
+});
+
+idleInput.addEventListener('change', () => {
+    const val = parseInt(idleInput.value, 10);
+    if (!isNaN(val) && val > 0) {
+        idleTimeout = val * 60 * 1000;
+    }
+    resetIdle();
+});
+
+window.addEventListener('beforeunload', saveCurrentTime);
+
+function init() {
+    idleInput.value = idleTimeout / 60000;
+    checkProjectChange();
+    startTimer();
+    resetIdle();
+    setInterval(checkProjectChange, 2000);
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/plugin/storage.js
+++ b/plugin/storage.js
@@ -1,0 +1,10 @@
+const STORAGE_PREFIX = 'projectTime_';
+
+function loadTime(project) {
+    const val = localStorage.getItem(STORAGE_PREFIX + project);
+    return val ? parseInt(val, 10) : 0;
+}
+
+function saveTime(project, seconds) {
+    localStorage.setItem(STORAGE_PREFIX + project, String(seconds));
+}

--- a/plugin/styles.css
+++ b/plugin/styles.css
@@ -13,15 +13,14 @@ body {
     text-align: center;
 }
 
-.project-select {
-    margin-bottom: 1rem;
+
+.project-name {
+    margin-bottom: 0.5rem;
+    font-weight: bold;
 }
 
-.project-select select {
-    padding: 0.25rem;
-    background-color: #333;
-    color: #fff;
-    border: 1px solid #555;
+.idle-config {
+    margin-bottom: 1rem;
 }
 
 .icon-btn {
@@ -41,16 +40,3 @@ body {
     margin-top: 0.5rem;
 }
 
-.icon-grid {
-    display: grid;
-    grid-template-columns: repeat(3, 40px);
-    grid-gap: 0.5rem;
-    justify-content: center;
-    margin-top: 1rem;
-}
-
-.icon-grid .icon-btn {
-    width: 40px;
-    height: 40px;
-    background-color: #333;
-}


### PR DESCRIPTION
## Summary
- show project name and idle timeout config in plugin UI
- add persistent storage for time per project
- implement timer with auto idle pause and project switching
- remove unused layout styles

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68682d54186c832c9951b47421d53170