### PR TITLE
Implement session limits and CSV export

### DIFF
--- a/plugin/index.html
+++ b/plugin/index.html
@@ -15,6 +15,11 @@
             <input id="idleInput" type="number" min="1" value="2" />
         </div>
 
+        <div class="session-config">
+            <label for="sessionInput">Session max (min):</label>
+            <input id="sessionInput" type="number" min="1" value="90" />
+        </div>
+
         <div id="timer">00:00:00</div>
 
         <div class="controls">
@@ -33,6 +38,13 @@
                 <svg viewBox="0 0 16 16" width="16" height="16">
                     <path d="M8 1v2.5A4.5 4.5 0 1 1 3.5 8" stroke="currentColor" fill="none" />
                     <polygon points="8,0 12,2 8,4" fill="currentColor" />
+                </svg>
+            </button>
+            <button id="exportBtn" class="icon-btn" aria-label="Export">
+                <svg viewBox="0 0 16 16" width="16" height="16">
+                    <path d="M8 0v10" stroke="currentColor" fill="none" />
+                    <polyline points="4,6 8,10 12,6" fill="none" stroke="currentColor" />
+                    <rect x="1" y="12" width="14" height="3" fill="currentColor" />
                 </svg>
             </button>
         </div>

--- a/plugin/main.js
+++ b/plugin/main.js
@@ -1,16 +1,28 @@
 let timer = null;
 let elapsedSeconds = 0;
+let sessionSeconds = 0;
 let idleTimeout = 2 * 60 * 1000; // 2 minutes default
 let idleTimer = null;
 let pausedByIdle = false;
 let currentProject = '';
+let sessionAlert = 90 * 60; // 90 minutes default
 
 const timerEl = document.getElementById('timer');
 const playBtn = document.getElementById('playBtn');
 const pauseBtn = document.getElementById('pauseBtn');
 const refreshBtn = document.getElementById('refreshBtn');
 const idleInput = document.getElementById('idleInput');
+const sessionInput = document.getElementById('sessionInput');
+const exportBtn = document.getElementById('exportBtn');
 const projectNameEl = document.getElementById('projectName');
+
+function parseTime(str) {
+    const parts = str.split(':').map(p => parseInt(p, 10));
+    if (parts.length === 3 && parts.every(n => !isNaN(n) && n >= 0)) {
+        return parts[0] * 3600 + parts[1] * 60 + parts[2];
+    }
+    return null;
+}
 
 function getProjectName() {
     try {
@@ -38,6 +50,11 @@ function startTimer() {
     if (timer) return;
     timer = setInterval(() => {
         elapsedSeconds++;
+        sessionSeconds++;
+        if (sessionSeconds >= sessionAlert) {
+            alert('Time to take a break!');
+            sessionSeconds = 0;
+        }
         updateDisplay();
     }, 1000);
     pausedByIdle = false;
@@ -48,6 +65,7 @@ function pauseTimer(byIdle = false) {
     clearInterval(timer);
     timer = null;
     pausedByIdle = byIdle;
+    sessionSeconds = 0;
 }
 
 function resumeTimer() {
@@ -59,6 +77,7 @@ function resumeTimer() {
 function resetTimer() {
     pauseTimer();
     elapsedSeconds = 0;
+    sessionSeconds = 0;
     updateDisplay();
 }
 
@@ -76,12 +95,17 @@ function loadCurrentProject() {
 function checkProjectChange() {
     const name = getProjectName();
     if (name !== currentProject) {
-        if (currentProject) {
+        if (currentProject && currentProject !== 'Untitled') {
             saveCurrentTime();
         }
         currentProject = name;
-        projectNameEl.textContent = currentProject;
+        projectNameEl.textContent = currentProject === 'Untitled' ? 'Unsaved Project' : currentProject;
         loadCurrentProject();
+        if (currentProject === 'Untitled') {
+            pauseTimer();
+        } else {
+            startTimer();
+        }
     }
 }
 
@@ -97,9 +121,39 @@ function resetIdle() {
     }
 }
 
+function exportCsv() {
+    const rows = ['Project,Total Time (HH:MM:SS)'];
+    for (let i = 0; i < localStorage.length; i++) {
+        const key = localStorage.key(i);
+        if (key.startsWith(STORAGE_PREFIX)) {
+            const project = key.slice(STORAGE_PREFIX.length);
+            const secs = parseInt(localStorage.getItem(key), 10) || 0;
+            rows.push(`${project},${formatTime(secs)}`);
+        }
+    }
+    const blob = new Blob([rows.join('\n')], { type: 'text/csv' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'time-tracking.csv';
+    a.click();
+    URL.revokeObjectURL(url);
+}
+
 playBtn.addEventListener('click', startTimer);
 pauseBtn.addEventListener('click', () => pauseTimer(false));
 refreshBtn.addEventListener('click', resetTimer);
+timerEl.addEventListener('click', () => {
+    const input = prompt('Set time (HH:MM:SS)', formatTime(elapsedSeconds));
+    if (!input) return;
+    const secs = parseTime(input.trim());
+    if (secs !== null) {
+        elapsedSeconds = secs;
+        sessionSeconds = 0;
+        updateDisplay();
+    }
+});
+exportBtn.addEventListener('click', exportCsv);
 
 ['mousemove', 'keydown', 'focus'].forEach(evt => {
     window.addEventListener(evt, resetIdle);
@@ -113,12 +167,19 @@ idleInput.addEventListener('change', () => {
     resetIdle();
 });
 
+sessionInput.addEventListener('change', () => {
+    const val = parseInt(sessionInput.value, 10);
+    if (!isNaN(val) && val > 0) {
+        sessionAlert = val * 60;
+    }
+});
+
 window.addEventListener('beforeunload', saveCurrentTime);
 
 function init() {
     idleInput.value = idleTimeout / 60000;
+    sessionInput.value = sessionAlert / 60;
     checkProjectChange();
-    startTimer();
     resetIdle();
     setInterval(checkProjectChange, 2000);
 }

--- a/plugin/styles.css
+++ b/plugin/styles.css
@@ -23,6 +23,10 @@ body {
     margin-bottom: 1rem;
 }
 
+.session-config {
+    margin-bottom: 1rem;
+}
+
 .icon-btn {
     background: none;
     border: none;


### PR DESCRIPTION
## Summary
- add session duration input and export button to UI
- style session config section
- enable break reminders, manual time entry, and CSV export in plugin script

## Testing
- `git status --short`
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_68682e8c96b8832cb394e2051fe3c39f