### PR TITLE
Add Premiere Pro support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,14 @@
 # ae-codex-test
+
+This repository contains a sample UXP panel called **Time Tracker**. The panel
+tracks how long you spend on the current project and can export a CSV summary.
+
+## Compatibility
+
+The extension works in Adobe After Effects (22.0 or later) and Premiere Pro
+(24.0 or later, including Premiere Pro 2025).
+
+## Installation
+
+Copy the `plugin` folder to your UXP extensions directory for the host
+application and enable the extension from the Extensions menu.

--- a/plugin/main.js
+++ b/plugin/main.js
@@ -26,11 +26,16 @@ function parseTime(str) {
 
 function getProjectName() {
     try {
-        if (app.project && app.project.file) {
-            return app.project.file.name;
+        if (app.project) {
+            if (app.project.file && app.project.file.name) {
+                return app.project.file.name;
+            }
+            if (app.project.name) {
+                return app.project.name;
+            }
         }
     } catch (e) {
-        // not running in AE or project unsaved
+        // not running in host app or project unsaved
     }
     return 'Untitled';
 }

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -4,10 +4,16 @@
   "name": "Time Tracker",
   "version": "1.0.0",
   "main": "index.html",
-  "host": {
-    "app": "AEFT",
-    "minVersion": "22.0"
-  },
+  "host": [
+    {
+      "app": "AEFT",
+      "minVersion": "22.0"
+    },
+    {
+      "app": "PPRO",
+      "minVersion": "24.0"
+    }
+  ],
   "ui": {
     "type": "panel",
     "menu": [


### PR DESCRIPTION
## Summary
- broaden plugin manifest to include Premiere Pro
- relax project name getter to work with Premiere Pro API
- document compatibility with Premiere Pro

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_686830e07430832c84d5f7144fd9ce18