### PR TITLE
Update manifest for Brandon Timer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,11 @@
 # ae-codex-test
 
-This repository contains a sample UXP panel called **Time Tracker**. The panel
+This repository contains a sample UXP panel called **Brandon Timer**. The panel
 tracks how long you spend on the current project and can export a CSV summary.
 
 ## Compatibility
 
-The extension works in Adobe After Effects (22.0 or later) and Premiere Pro
-(24.0 or later, including Premiere Pro 2025).
+The extension works in Premiere Pro only (version 24.0.0 or later).
 
 ## Installation
 

--- a/plugin/index.html
+++ b/plugin/index.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <title>Time Tracker</title>
+    <title>Brandon Timer</title>
     <link rel="stylesheet" href="styles.css">
 </head>
 <body>
     <div class="container">
-        <h1>Time Tracker</h1>
+        <h1>Brandon Timer</h1>
         <div id="projectName" class="project-name">Project</div>
 
         <div class="idle-config">

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -1,26 +1,20 @@
 {
-  "manifestVersion": 4,
-  "id": "com.example.timetracker",
-  "name": "Time Tracker",
+  "manifestVersion": 5,
+  "id": "com.brandon.timetracker",
+  "name": "Brandon Timer",
   "version": "1.0.0",
   "main": "index.html",
-  "host": [
+  "host": {
+    "app": "PPRO",
+    "minVersion": "24.0.0"
+  },
+  "entrypoints": [
     {
-      "app": "AEFT",
-      "minVersion": "22.0"
-    },
-    {
-      "app": "PPRO",
-      "minVersion": "24.0"
+      "type": "panel",
+      "id": "brandon-timer",
+      "label": "Brandon Timer",
+      "icon": "icon.png",
+      "menuItems": []
     }
-  ],
-  "ui": {
-    "type": "panel",
-    "menu": [
-      {
-        "label": "Time Tracker",
-        "command": "open"
-      }
-    ]
-  }
+  ]
 }


### PR DESCRIPTION
## Summary
- rename panel to **Brandon Timer**
- update manifest to UXP v5 format
- update readme and UI text

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686833911abc832ca4ac6333572bf40d