### PR TITLE
Add After Effects support

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ tracks how long you spend on the current project and can export a CSV summary.
 
 ## Compatibility
 
-The extension works in Premiere Pro only (version 24.0.0 or later).
+The extension works in Premiere Pro and After Effects (version 24.0.0 or later).
 
 ## Installation
 

--- a/plugin/manifest.json
+++ b/plugin/manifest.json
@@ -4,10 +4,16 @@
   "name": "Brandon Timer",
   "version": "1.0.0",
   "main": "index.html",
-  "host": {
-    "app": "PPRO",
-    "minVersion": "24.0.0"
-  },
+  "host": [
+    {
+      "app": "PPRO",
+      "minVersion": "24.0.0"
+    },
+    {
+      "app": "AEFT",
+      "minVersion": "24.0.0"
+    }
+  ],
   "entrypoints": [
     {
       "type": "panel",


### PR DESCRIPTION
## Summary
- add AEFT host entry in manifest.json
- document After Effects compatibility in README

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68683520303c832cb99519e99a0f29ba